### PR TITLE
Replace engine if/else chain with self-registering engine registry

### DIFF
--- a/js/avatars/clippy-controller.js
+++ b/js/avatars/clippy-controller.js
@@ -2,6 +2,7 @@ import { officePackPlugin } from "../lib/clippy-3d-plugin-examples.js";
 import { createClippy3D } from "../lib/clippy-3d.js";
 import { clamp, constrainPupilToEyeSurface } from "../lib/utils.js";
 import { NO_PROP_VALUE } from "../config/avatars.js";
+import { registerEngine } from "../engines.js";
 
 const FALLBACK_MODES = ["idle", "wave", "celebrate", "spin", "point"];
 const EXPRESSION_CHOICES = ["neutral", "happy", "focused", "surprised"];
@@ -572,3 +573,5 @@ export function createClippyController({ THREE, scene, initialState }) {
     },
   };
 }
+
+registerEngine("clippy", createClippyController);

--- a/js/avatars/thumbtack-controller.js
+++ b/js/avatars/thumbtack-controller.js
@@ -1,5 +1,6 @@
 import { createThumbTackAvatar, expressionProfile } from "../lib/thumbtack-factory.js";
 import { clamp, constrainPupilToEyeSurface } from "../lib/utils.js";
+import { registerEngine } from "../engines.js";
 
 const MODE_CHOICES = ["idle", "bob", "wave", "spin", "celebrate"];
 const EXPRESSION_CHOICES = ["neutral", "smile", "determined", "startled"];
@@ -263,3 +264,5 @@ export function createThumbtackController({ THREE, scene, initialState, profile,
     },
   };
 }
+
+registerEngine("thumbtack", createThumbtackController);

--- a/js/avatars/towely-controller.js
+++ b/js/avatars/towely-controller.js
@@ -1,5 +1,6 @@
 import { createTowelyAvatar } from "../lib/towely-factory.js";
 import { clamp } from "../lib/utils.js";
+import { registerEngine } from "../engines.js";
 
 const MODE_CHOICES = ["idle", "bob", "wave", "spin", "celebrate"];
 const EXPRESSION_CHOICES = ["neutral", "smug", "angry", "startled"];
@@ -459,3 +460,5 @@ export function createTowelyController({ THREE, scene, initialState, stageTopY }
     },
   };
 }
+
+registerEngine("towely", createTowelyController);

--- a/js/config/avatars.js
+++ b/js/config/avatars.js
@@ -216,6 +216,7 @@ export const AVATAR_DEFINITIONS = {
     label: "Clippy",
     description: "Classic assistant paperclip with office props and expression controls.",
     engine: "clippy",
+    order: 0,
     scenePreset: "clippy",
     controls: clippyFields,
     defaultState: {
@@ -261,6 +262,8 @@ export const AVATAR_DEFINITIONS = {
     description: "Push pin avatar with layered cap profile and animated expressions.",
     engine: "thumbtack",
     profile: "pushy",
+    order: 1,
+    stageTopY: -2.67,
     scenePreset: "pin",
     controls: pinFields,
     defaultState: {
@@ -302,6 +305,8 @@ export const AVATAR_DEFINITIONS = {
     description: "Thumb tack mascot with rounded cap profile and playful animation.",
     engine: "thumbtack",
     profile: "tacky",
+    order: 2,
+    stageTopY: -2.67,
     scenePreset: "pin",
     controls: pinFields,
     defaultState: {
@@ -342,6 +347,8 @@ export const AVATAR_DEFINITIONS = {
     label: "Towely",
     description: "Sentient towel mascot with expressive face and bendable limbs.",
     engine: "towely",
+    order: 3,
+    stageTopY: -2.67,
     scenePreset: "towel",
     controls: towelyFields,
     defaultState: {
@@ -386,7 +393,8 @@ export const AVATAR_DEFINITIONS = {
   },
 };
 
-export const AVATAR_ORDER = ["clippy", "pushy", "tacky", "towely"];
+export const AVATAR_ORDER = Object.keys(AVATAR_DEFINITIONS)
+  .sort((a, b) => (AVATAR_DEFINITIONS[a].order ?? 0) - (AVATAR_DEFINITIONS[b].order ?? 0));
 
 export const SCENE_PRESETS = {
   clippy: {
@@ -412,5 +420,3 @@ export const SCENE_PRESETS = {
   },
 };
 
-export const PIN_STAGE_TOP_Y = -2.67;
-export const TOWELY_STAGE_TOP_Y = -2.67;

--- a/js/engines.js
+++ b/js/engines.js
@@ -1,0 +1,23 @@
+/**
+ * Self-registering engine registry.
+ *
+ * Each avatar engine module calls registerEngine() on import to add itself.
+ * The studio resolves engines by name via getEngine() — no hardcoded
+ * if/else chain or per-engine imports required in the host module.
+ */
+
+const engineRegistry = new Map();
+
+export function registerEngine(name, factory) {
+  engineRegistry.set(name, factory);
+}
+
+export function getEngine(name) {
+  const factory = engineRegistry.get(name);
+  if (!factory) {
+    throw new Error(
+      `Unknown engine "${name}". Registered: ${[...engineRegistry.keys()].join(", ") || "(none)"}`,
+    );
+  }
+  return factory;
+}

--- a/js/studio.js
+++ b/js/studio.js
@@ -4,12 +4,12 @@ import {
   AVATAR_DEFINITIONS,
   AVATAR_ORDER,
   NO_PROP_VALUE,
-  PIN_STAGE_TOP_Y,
-  TOWELY_STAGE_TOP_Y,
 } from "./config/avatars.js";
-import { createClippyController } from "./avatars/clippy-controller.js";
-import { createThumbtackController } from "./avatars/thumbtack-controller.js";
-import { createTowelyController } from "./avatars/towely-controller.js";
+import { getEngine } from "./engines.js";
+// Side-effect imports: each controller self-registers its engine on load.
+import "./avatars/clippy-controller.js";
+import "./avatars/thumbtack-controller.js";
+import "./avatars/towely-controller.js";
 import { clamp, randomBetween, randomColor } from "./lib/utils.js";
 import { createRealtimeVoice } from "./lib/realtime-voice.js";
 import { createElevenLabsVoice } from "./lib/elevenlabs-voice.js";
@@ -660,39 +660,13 @@ function applyScenePreset() {
 }
 
 function createController(definition, initialState) {
-  if (definition.engine === "clippy") {
-    return createClippyController({
-      THREE,
-      scene,
-      initialState,
-    });
-  }
-
-  if (definition.engine === "thumbtack") {
-    return createThumbtackController({
-      THREE,
-      scene,
-      initialState,
-      profile: definition.profile,
-      stageTopY: PIN_STAGE_TOP_Y,
-    });
-  }
-
-  if (definition.engine === "towely") {
-    return createTowelyController({
-      THREE,
-      scene,
-      initialState,
-      stageTopY: TOWELY_STAGE_TOP_Y,
-    });
-  }
-
-  return createThumbtackController({
+  const factory = getEngine(definition.engine);
+  return factory({
     THREE,
     scene,
     initialState,
     profile: definition.profile,
-    stageTopY: PIN_STAGE_TOP_Y,
+    stageTopY: definition.stageTopY,
   });
 }
 


### PR DESCRIPTION
## Summary
- Introduce `js/engines.js` with `registerEngine()`/`getEngine()` registry pattern
- Each controller module self-registers its engine on import — no hardcoded dispatch needed
- Replace the if/else chain in `studio.js:createController()` with a single `getEngine()` call
- Move `PIN_STAGE_TOP_Y` / `TOWELY_STAGE_TOP_Y` constants into avatar definition objects as `stageTopY`
- Derive `AVATAR_ORDER` from definition `order` fields instead of a hardcoded array

Adding a new avatar engine is now purely additive — drop in a definition + engine, zero edits to `studio.js`.

## Test plan
- [ ] `npm run check` passes (syntax + lint + build)
- [ ] All four avatars load and behave identically to before
- [ ] Carousel order is unchanged (clippy, pushy, tacky, towely)
- [ ] Voice and control panel work as before

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)