### PR TITLE
Add controller interface validation and missing voice methods

### DIFF
--- a/js/avatars/thumbtack-controller.js
+++ b/js/avatars/thumbtack-controller.js
@@ -241,6 +241,11 @@ export function createThumbtackController({ THREE, scene, initialState, profile,
     runtime.voiceTarget = clamp(Number.isFinite(next) ? next : 0, 0, 1);
   }
 
+  function setVoiceViseme(_payload) {
+    // Thumbtack uses voice-activity-driven mouth animation;
+    // viseme-specific shaping is not yet implemented for this engine.
+  }
+
   function dispose() {
     scene.remove(avatar.group);
     avatar.dispose();
@@ -253,6 +258,7 @@ export function createThumbtackController({ THREE, scene, initialState, profile,
     setState,
     update,
     setVoiceActivity,
+    setVoiceViseme,
     dispose,
     getCatalog() {
       return {

--- a/js/avatars/towely-controller.js
+++ b/js/avatars/towely-controller.js
@@ -170,6 +170,9 @@ export function createTowelyController({ THREE, scene, initialState, stageTopY }
     modeBlend: 1,
     blinkTimer: 0,
     blinkOffset: 0.34,
+    voiceTarget: 0,
+    voiceCurrent: 0,
+    voicePhase: Math.random() * Math.PI * 2,
   };
 
   function updateMaterials() {
@@ -411,6 +414,23 @@ export function createTowelyController({ THREE, scene, initialState, stageTopY }
     avatar.rightPupil.scale.set(runtime.pupilBaseScale, runtime.pupilBaseScale * pupilYScale, 1);
   }
 
+  function applyVoiceFrame(dt) {
+    const smoothing = runtime.voiceTarget > runtime.voiceCurrent ? 0.38 : 0.2;
+    runtime.voiceCurrent += (runtime.voiceTarget - runtime.voiceCurrent) * smoothing;
+    if (runtime.voiceCurrent < 0.004) runtime.voiceCurrent = 0;
+
+    runtime.voicePhase += dt * (24 + runtime.voiceCurrent * 32);
+
+    const flutter = Math.sin(runtime.voicePhase) * 0.06 * runtime.voiceCurrent;
+    const open = clamp(runtime.voiceCurrent * 0.72 + flutter, 0, 1.2);
+
+    const expr = expressionProfile(state.expression);
+    const mouthWidth = clamp(state.mouthWidth * expr.mouthWidth, 0.6, 1.8);
+    const mouthOpen = clamp(state.mouthOpen + expr.mouthOpen + open, 0, 1.3);
+
+    avatar.smile.scale.set(0.88 * mouthWidth, 0.86 + mouthOpen * 0.16, 1);
+  }
+
   function setState(nextState = {}, { force = false } = {}) {
     Object.assign(state, nextState);
 
@@ -436,6 +456,17 @@ export function createTowelyController({ THREE, scene, initialState, stageTopY }
     }
 
     applyAnimationFrame(frameDt);
+    applyVoiceFrame(frameDt);
+  }
+
+  function setVoiceActivity(level = 0) {
+    const next = Number(level);
+    runtime.voiceTarget = clamp(Number.isFinite(next) ? next : 0, 0, 1);
+  }
+
+  function setVoiceViseme(_payload) {
+    // Towely uses voice-activity-driven mouth animation;
+    // viseme-specific shaping is not yet implemented for this engine.
   }
 
   function dispose() {
@@ -449,6 +480,8 @@ export function createTowelyController({ THREE, scene, initialState, stageTopY }
     group: avatar.group,
     setState,
     update,
+    setVoiceActivity,
+    setVoiceViseme,
     dispose,
     getCatalog() {
       return {

--- a/js/lib/controller-utils.js
+++ b/js/lib/controller-utils.js
@@ -1,0 +1,36 @@
+/**
+ * Shared controller interface validation and utilities.
+ *
+ * Every avatar controller must implement the same interface so that the studio
+ * runtime can drive any avatar uniformly. This module provides early validation
+ * and shared helpers to reduce duplication across engine implementations.
+ */
+
+const REQUIRED_CONTROLLER_KEYS = [
+  "group",
+  "setState",
+  "update",
+  "setVoiceActivity",
+  "setVoiceViseme",
+  "dispose",
+  "getCatalog",
+];
+
+/**
+ * Validate that a controller object implements the full avatar controller
+ * interface. Throws on violation so bugs are caught at creation time.
+ */
+export function assertControllerInterface(controller, engineName) {
+  if (!controller || typeof controller !== "object") {
+    throw new Error(`Engine "${engineName}" factory must return an object.`);
+  }
+
+  for (const key of REQUIRED_CONTROLLER_KEYS) {
+    if (!(key in controller)) {
+      throw new Error(
+        `Engine "${engineName}" controller missing required member: "${key}". ` +
+        `Required interface: [${REQUIRED_CONTROLLER_KEYS.join(", ")}]`,
+      );
+    }
+  }
+}

--- a/js/studio.js
+++ b/js/studio.js
@@ -13,6 +13,7 @@ import { createTowelyController } from "./avatars/towely-controller.js";
 import { clamp, randomBetween, randomColor } from "./lib/utils.js";
 import { createRealtimeVoice } from "./lib/realtime-voice.js";
 import { createElevenLabsVoice } from "./lib/elevenlabs-voice.js";
+import { assertControllerInterface } from "./lib/controller-utils.js";
 
 const canvas = document.getElementById("studioCanvas");
 const stageEl = document.querySelector(".stage");
@@ -712,6 +713,7 @@ function createAvatarRuntimes() {
 
     const initialState = { ...definition.defaultState };
     const controller = createController(definition, initialState);
+    assertControllerInterface(controller, definition.engine);
     const catalog = controller.getCatalog();
     const state = sanitizeState(definition, initialState, catalog, definition.defaultState);
 


### PR DESCRIPTION
## Summary
- Add `assertControllerInterface()` in `js/lib/controller-utils.js` that validates every controller implements the required interface at creation time
- Fix **towely-controller** missing `setVoiceActivity` and `setVoiceViseme` — Towely now responds to voice input with mouth animation
- Fix **thumbtack-controller** missing `setVoiceViseme` — added as no-op since thumbtack uses activity-driven mouth animation
- Validation runs in `studio.js:createAvatarRuntimes()` immediately after controller creation

Required interface: `group`, `setState`, `update`, `setVoiceActivity`, `setVoiceViseme`, `dispose`, `getCatalog`

## Test plan
- [ ] `npm run check` passes (syntax + lint + build)
- [ ] All four avatars load without validation errors
- [ ] Towely mouth animates during voice activity (was previously silent)
- [ ] Removing a required method from any controller throws immediately on load

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)