### PR TITLE
Universal mouth rig with placement controls for all avatars

### DIFF
--- a/js/avatars/clippy-controller.js
+++ b/js/avatars/clippy-controller.js
@@ -3,6 +3,7 @@ import { createClippy3D } from "../lib/clippy-3d.js";
 import { clamp, constrainPupilToEyeSurface } from "../lib/utils.js";
 import { registerEngine } from "../engines.js";
 import { createPropManager, listSharedProps, getSharedProp, loadPropPlacement, savePropPlacement, applyPlacementToObject } from "../lib/prop-system.js";
+import { createUniversalMouth } from "../lib/mouth-rig.js";
 import "../lib/shared-props.js";
 import { NO_PROP_VALUE } from "../config/avatars.js";
 
@@ -76,98 +77,6 @@ function setMaterialEmissive(material, value, intensity) {
   material.needsUpdate = true;
 }
 
-function blendPose(base, target, amount) {
-  const mix = clamp(amount, 0, 1);
-  return {
-    open: base.open + (target.open - base.open) * mix,
-    width: base.width + (target.width - base.width) * mix,
-    round: base.round + (target.round - base.round) * mix,
-    press: base.press + (target.press - base.press) * mix,
-    jaw: base.jaw + (target.jaw - base.jaw) * mix,
-  };
-}
-
-function createMouthRig(THREE, sourceMouth) {
-  if (!sourceMouth || !sourceMouth.parent) return null;
-  const parent = sourceMouth.parent;
-  const basePosition = sourceMouth.position.clone();
-  const baseRotation = sourceMouth.rotation.clone();
-  const baseScale = sourceMouth.scale.clone();
-
-  // Root stays unrotated so width/height sliders scale on intuitive axes.
-  const group = new THREE.Group();
-  group.position.copy(basePosition);
-
-  // Inner pivot preserves original orientation of the original mouth mesh.
-  const shapeGroup = new THREE.Group();
-  shapeGroup.rotation.copy(baseRotation);
-  shapeGroup.scale.copy(baseScale);
-  group.add(shapeGroup);
-
-  const lipMaterial = sourceMouth.material?.clone?.()
-    || new THREE.MeshStandardMaterial({ color: 0x0f172a, metalness: 0.2, roughness: 0.65 });
-  lipMaterial.color.setHex(LIP_COLOR);
-  const cavityMaterial = new THREE.MeshBasicMaterial({ color: 0x070b16 });
-  const shadowMaterial = new THREE.MeshBasicMaterial({
-    color: 0x02040a,
-    transparent: true,
-    opacity: 0.6,
-    depthWrite: false,
-  });
-  const tongueMaterial = new THREE.MeshStandardMaterial({
-    color: 0x7d3445,
-    metalness: 0.02,
-    roughness: 0.88,
-  });
-
-  const upperLip = new THREE.Mesh(new THREE.TorusGeometry(0.16, 0.024, 12, 38, Math.PI), lipMaterial);
-  upperLip.rotation.z = Math.PI;
-  upperLip.position.y = 0.008;
-
-  const lowerLip = new THREE.Mesh(new THREE.TorusGeometry(0.16, 0.026, 12, 38, Math.PI), lipMaterial);
-  lowerLip.position.y = -0.008;
-
-  const cavity = new THREE.Mesh(new THREE.CircleGeometry(0.13, 32), cavityMaterial);
-  cavity.position.z = -0.008;
-  cavity.scale.set(0.84, 0.08, 1);
-
-  const cavityShadow = new THREE.Mesh(new THREE.CircleGeometry(0.136, 32), shadowMaterial);
-  cavityShadow.position.set(0, -0.006, -0.018);
-  cavityShadow.scale.set(0.92, 0.12, 1);
-
-  const tongue = new THREE.Mesh(new THREE.CircleGeometry(0.078, 24), tongueMaterial);
-  tongue.position.set(0, -0.052, -0.014);
-  tongue.scale.set(0.72, 0.26, 1);
-  tongue.visible = false;
-
-  upperLip.visible = false;
-  lowerLip.visible = false;
-  cavity.visible = false;
-  cavityShadow.visible = false;
-
-  sourceMouth.position.set(0, 0, 0);
-  sourceMouth.rotation.set(0, 0, 0);
-  sourceMouth.scale.set(1, 1, 1);
-  sourceMouth.material = lipMaterial;
-  sourceMouth.visible = true;
-
-  shapeGroup.add(sourceMouth, cavityShadow, cavity, tongue, upperLip, lowerLip);
-  parent.add(group);
-
-  return {
-    group,
-    baseMouth: sourceMouth,
-    upperLip,
-    lowerLip,
-    cavity,
-    cavityShadow,
-    tongue,
-    lipMaterial,
-    cavityMaterial,
-    shadowMaterial,
-  };
-}
-
 export function createClippyController({ THREE, scene, initialState, avatarId }) {
   const state = { ...initialState };
   const plugins = [officePackPlugin].filter(Boolean);
@@ -180,7 +89,22 @@ export function createClippyController({ THREE, scene, initialState, avatarId })
   });
   scene.add(clippy.group);
 
-  const mouthRig = createMouthRig(THREE, clippy.mouth);
+  // Create universal mouth rig and attach to head
+  const cavityColorBase = new THREE.Color(state.darkColor).multiplyScalar(0.4).getHex();
+  const shadowColorBase = new THREE.Color(state.darkColor).multiplyScalar(0.26).getHex();
+
+  const mouthRig = createUniversalMouth({
+    THREE,
+    anchor: clippy.head,
+    options: {
+      lipColor: LIP_COLOR,
+      cavityColor: cavityColorBase,
+      tongueColor: 0x7d3445,
+      shadowColor: shadowColorBase,
+      shadowOpacity: 0.6,
+    },
+  });
+
   if (mouthRig?.group) {
     clippy.mouth = mouthRig.group;
   }
@@ -237,13 +161,8 @@ export function createClippyController({ THREE, scene, initialState, avatarId })
 
   const voiceRuntime = {
     target: 0,
-    current: 0,
-    expression: expressionProfile(state.expression),
     visemeKey: SIL_VISEME,
     visemeStrengthTarget: 0,
-    visemeStrengthCurrent: 0,
-    poseCurrent: { ...VISEME_POSES[SIL_VISEME] },
-    phase: Math.random() * Math.PI * 2,
   };
 
   function applyMaterialState() {
@@ -271,11 +190,11 @@ export function createClippyController({ THREE, scene, initialState, avatarId })
     setMaterialColor(rightPupilMaterial, state.darkColor);
     setMaterialColor(rightEyeMaterial, state.eyeColor);
 
-    if (mouthRig) {
-      setMaterialColor(mouthRig.lipMaterial, LIP_COLOR);
+    if (mouthRig?.materials) {
+      setMaterialColor(mouthRig.materials.lipMaterial, LIP_COLOR);
       const cavityColor = new THREE.Color(state.darkColor).multiplyScalar(0.4);
-      setMaterialColor(mouthRig.cavityMaterial, cavityColor);
-      setMaterialColor(mouthRig.shadowMaterial, new THREE.Color(state.darkColor).multiplyScalar(0.26));
+      setMaterialColor(mouthRig.materials.cavityMaterial, cavityColor);
+      setMaterialColor(mouthRig.materials.shadowMaterial, new THREE.Color(state.darkColor).multiplyScalar(0.26));
     }
   }
 
@@ -369,110 +288,61 @@ export function createClippyController({ THREE, scene, initialState, avatarId })
     clippy.rightArm.pivot.position.x = state.armSpread;
     clippy.leftArm.pivot.position.y = state.armY;
     clippy.rightArm.pivot.position.y = state.armY;
+
+    // Apply mouth rig placement
+    applyMouthPlacement();
+  }
+
+  function loadMouthPlacement() {
+    const storageKey = `mouth-placement:${avatarId}`;
+    try {
+      const saved = localStorage.getItem(storageKey);
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        state.mouthRigX = parsed.x ?? state.mouthRigX;
+        state.mouthRigY = parsed.y ?? state.mouthRigY;
+        state.mouthRigZ = parsed.z ?? state.mouthRigZ;
+        state.mouthRigScale = parsed.scale ?? state.mouthRigScale;
+        state.mouthRigRotX = parsed.rotX ?? state.mouthRigRotX;
+        state.mouthRigRotY = parsed.rotY ?? state.mouthRigRotY;
+        state.mouthRigRotZ = parsed.rotZ ?? state.mouthRigRotZ;
+      }
+    } catch { /* ignore */ }
+  }
+
+  function saveMouthPlacement() {
+    const storageKey = `mouth-placement:${avatarId}`;
+    try {
+      localStorage.setItem(storageKey, JSON.stringify({
+        x: state.mouthRigX,
+        y: state.mouthRigY,
+        z: state.mouthRigZ,
+        scale: state.mouthRigScale,
+        rotX: state.mouthRigRotX,
+        rotY: state.mouthRigRotY,
+        rotZ: state.mouthRigRotZ,
+      }));
+    } catch { /* ignore */ }
+  }
+
+  function applyMouthPlacement() {
+    if (!clippy.mouth) return;
+    clippy.mouth.position.x = state.mouthRigX;
+    clippy.mouth.position.y = state.mouthRigY;
+    clippy.mouth.position.z = state.mouthRigZ;
+    clippy.mouth.scale.setScalar(state.mouthRigScale);
+    clippy.mouth.rotation.set(state.mouthRigRotX, state.mouthRigRotY, state.mouthRigRotZ);
   }
 
   function applyVoiceFrame(dt) {
-    if (!clippy.mouth) return;
-
-    const levelSmoothing = voiceRuntime.target > voiceRuntime.current ? 0.36 : 0.22;
-    voiceRuntime.current += (voiceRuntime.target - voiceRuntime.current) * levelSmoothing;
-    if (voiceRuntime.current < 0.004) voiceRuntime.current = 0;
-
-    const visemeSmoothing = voiceRuntime.visemeStrengthTarget > voiceRuntime.visemeStrengthCurrent ? 0.4 : 0.24;
-    voiceRuntime.visemeStrengthCurrent += (voiceRuntime.visemeStrengthTarget - voiceRuntime.visemeStrengthCurrent) * visemeSmoothing;
-    if (voiceRuntime.visemeStrengthCurrent < 0.004) voiceRuntime.visemeStrengthCurrent = 0;
-
-    const targetPose = VISEME_POSES[voiceRuntime.visemeKey] || VISEME_POSES[SIL_VISEME];
-    const mixedPose = blendPose(VISEME_POSES[SIL_VISEME], targetPose, voiceRuntime.visemeStrengthCurrent);
-
-    for (const key of ["open", "width", "round", "press", "jaw"]) {
-      const from = voiceRuntime.poseCurrent[key];
-      const to = mixedPose[key];
-      voiceRuntime.poseCurrent[key] = from + (to - from) * 0.34;
-    }
-
-    const expr = voiceRuntime.expression;
-    const activity = clamp(voiceRuntime.current * 0.8 + voiceRuntime.visemeStrengthCurrent * 0.64, 0, 1);
-
-    voiceRuntime.phase += dt * (14 + activity * 20);
-    const flutter = Math.sin(voiceRuntime.phase) * 0.04 * activity;
-
-    const openAmount = clamp(voiceRuntime.poseCurrent.open * (0.14 + activity * 0.66) + flutter, 0, 1.1);
-    const widthAmount = clamp(voiceRuntime.poseCurrent.width + activity * 0.05, 0.74, 1.45);
-    const roundAmount = clamp(voiceRuntime.poseCurrent.round, -0.22, 0.92);
-    const pressAmount = clamp(voiceRuntime.poseCurrent.press, 0, 1);
-    const jawAmount = clamp(voiceRuntime.poseCurrent.jaw, 0, 1);
-    const sealAmount = clamp(pressAmount * (1 - activity * 0.28), 0, 1);
-    const aperture = clamp(openAmount * (1 - sealAmount * 0.58), 0, 1.2);
-    const isBilabial = voiceRuntime.visemeKey === "mbp";
-    const bilabialLock = isBilabial ? voiceRuntime.visemeStrengthCurrent : 0;
-    const bridgeBoost =
-      clamp((0.24 - aperture) / 0.24, 0, 1)
-      * clamp(activity * 0.12 + voiceRuntime.current * 0.09, 0, 0.14);
-    const bridgeOpen = clamp((aperture + bridgeBoost) * (1 - bilabialLock * 0.95), 0, 1.16);
-    const mouthOffsetY = Number.isFinite(state.mouthOffsetY) ? state.mouthOffsetY : 0;
-    const mouthOffsetZ = mouthOffsetY * MOUTH_OFFSET_Z_FACTOR;
-
-    const mouthScaleY = expr.mouthScaleY * state.mouthHeight * (0.96 + bridgeOpen * 0.5 + (1 - sealAmount) * 0.03);
-    const mouthScaleAnchorY = (1 - mouthScaleY) * MOUTH_SCALE_ANCHOR_Y;
-    clippy.mouth.scale.x = state.mouthWidth * widthAmount;
-    clippy.mouth.scale.y = mouthScaleY;
-    clippy.mouth.position.y = expr.mouthShiftY + mouthOffsetY + mouthScaleAnchorY - activity * 0.015 - jawAmount * 0.016;
-    clippy.mouth.position.z = base.mouthZ + mouthOffsetZ;
-
     if (!mouthRig) return;
 
-    let useRig =
-      aperture > 0.11
-      || voiceRuntime.current > 0.22
-      || voiceRuntime.visemeStrengthCurrent > 0.1;
-    if (bilabialLock > 0.36) {
-      useRig = false;
-    }
-    mouthRig.baseMouth.visible = !useRig;
-    mouthRig.upperLip.visible = useRig;
-    mouthRig.lowerLip.visible = useRig;
-    if (!useRig) {
-      mouthRig.cavity.visible = false;
-      mouthRig.cavityShadow.visible = false;
-      mouthRig.tongue.visible = false;
-      return;
-    }
-
-    const lipSpread = clamp(1 + (widthAmount - 1) * 0.36 - roundAmount * 0.1, 0.78, 1.48);
-    const closedBlend = clamp((bridgeOpen - 0.03) / 0.14, 0, 1);
-    const upperLift = 0.004 + bridgeOpen * 0.016 - sealAmount * 0.012;
-    const lowerDrop = -0.004 - bridgeOpen * 0.098 - jawAmount * 0.03 + sealAmount * 0.01;
-
-    mouthRig.upperLip.position.y = upperLift;
-    mouthRig.lowerLip.position.y = lowerDrop * closedBlend;
-    mouthRig.lowerLip.visible = true;
-
-    mouthRig.upperLip.scale.x = lipSpread;
-    mouthRig.lowerLip.scale.x = clamp(lipSpread * (1 + roundAmount * 0.06), 0.76, 1.56);
-
-    mouthRig.upperLip.scale.y = clamp(1 - sealAmount * 0.28 + roundAmount * 0.08, 0.74, 1.24);
-    mouthRig.lowerLip.scale.y = clamp(0.7 + closedBlend * (0.3 - sealAmount * 0.32 + roundAmount * 0.1), 0.7, 1.28);
-
-    const cavityOpen = clamp(
-      (bridgeOpen * (0.92 - sealAmount * 0.38) + activity * 0.05) * (1 - bilabialLock * 1.2),
-      0,
-      1.12,
-    );
-    mouthRig.cavity.visible = cavityOpen > 0.03;
-    mouthRig.cavity.scale.x = clamp(1.08 + (lipSpread - 1) * 0.36 + bridgeOpen * 0.06 - roundAmount * 0.04, 0.96, 1.28);
-    mouthRig.cavity.scale.y = clamp(0.54 + cavityOpen * 0.72 + roundAmount * 0.08, 0.48, 1.28);
-    mouthRig.cavity.position.y = -0.002 - cavityOpen * 0.055;
-
-    mouthRig.cavityShadow.visible = mouthRig.cavity.visible;
-    mouthRig.cavityShadow.scale.x = clamp(mouthRig.cavity.scale.x * 1.04, 0.96, 1.34);
-    mouthRig.cavityShadow.scale.y = clamp(mouthRig.cavity.scale.y * 1.08, 0.5, 1.42);
-    mouthRig.cavityShadow.position.y = mouthRig.cavity.position.y - 0.003;
-
-    mouthRig.tongue.visible = cavityOpen > 0.3 && bilabialLock < 0.28;
-    mouthRig.tongue.scale.x = clamp(0.52 + lipSpread * 0.2, 0.42, 0.98);
-    mouthRig.tongue.scale.y = clamp(0.16 + cavityOpen * 0.42, 0.14, 0.72);
-    mouthRig.tongue.position.y = -0.052 - cavityOpen * 0.05;
+    // Delegate voice animation to the universal mouth rig
+    mouthRig.applyVoiceFrame(dt, {
+      viseme: voiceRuntime.visemeKey,
+      visemeStrength: voiceRuntime.visemeStrengthTarget,
+      voiceActivity: voiceRuntime.target,
+    });
   }
 
   function applyPropPlacement() {
@@ -572,6 +442,7 @@ export function createClippyController({ THREE, scene, initialState, avatarId })
         rotX: state.propRotX, rotY: state.propRotY, rotZ: state.propRotZ,
       });
     }
+    saveMouthPlacement();
   }
 
   function update(dt, pointer) {
@@ -613,6 +484,9 @@ export function createClippyController({ THREE, scene, initialState, avatarId })
       clippy.dispose();
     }
   }
+
+  // Load saved mouth placement from localStorage
+  loadMouthPlacement();
 
   setState(state, { force: true });
 

--- a/js/avatars/clippy-controller.js
+++ b/js/avatars/clippy-controller.js
@@ -3,7 +3,7 @@ import { createClippy3D } from "../lib/clippy-3d.js";
 import { clamp, constrainPupilToEyeSurface } from "../lib/utils.js";
 import { registerEngine } from "../engines.js";
 import { createPropManager, listSharedProps, getSharedProp, loadPropPlacement, savePropPlacement, applyPlacementToObject } from "../lib/prop-system.js";
-import { createUniversalMouth } from "../lib/mouth-rig.js";
+import { createUniversalMouth, VISEME_POSES } from "../lib/mouth-rig.js";
 import "../lib/shared-props.js";
 import { NO_PROP_VALUE } from "../config/avatars.js";
 
@@ -11,23 +11,6 @@ const FALLBACK_MODES = ["idle", "wave", "celebrate", "spin", "point"];
 const EXPRESSION_CHOICES = ["neutral", "happy", "focused", "surprised"];
 const SIL_VISEME = "sil";
 const LIP_COLOR = 0xb53b4e;
-const MOUTH_OFFSET_Z_FACTOR = -0.22;
-const MOUTH_SCALE_ANCHOR_Y = 0.07;
-
-const VISEME_POSES = Object.freeze({
-  sil: { open: 0, width: 1, round: 0, press: 1, jaw: 0 },
-  aa: { open: 0.82, width: 1.11, round: 0.08, press: 0.05, jaw: 0.52 },
-  ee: { open: 0.32, width: 1.3, round: -0.14, press: 0.08, jaw: 0.12 },
-  oh: { open: 0.66, width: 0.9, round: 0.72, press: 0.09, jaw: 0.32 },
-  ou: { open: 0.48, width: 0.8, round: 0.84, press: 0.12, jaw: 0.2 },
-  fv: { open: 0.16, width: 1.02, round: 0.02, press: 0.45, jaw: 0.04 },
-  mbp: { open: 0, width: 1, round: 0, press: 1, jaw: 0 },
-  th: { open: 0.36, width: 1.08, round: 0.1, press: 0.22, jaw: 0.16 },
-  ch: { open: 0.44, width: 1.01, round: 0.18, press: 0.2, jaw: 0.2 },
-  tn: { open: 0.24, width: 1.08, round: 0.04, press: 0.28, jaw: 0.1 },
-  ss: { open: 0.14, width: 1.22, round: -0.04, press: 0.24, jaw: 0.06 },
-  kk: { open: 0.28, width: 1.02, round: 0.06, press: 0.26, jaw: 0.12 },
-});
 
 const CLIPPY_EYE_RADIUS = 0.22;
 const CLIPPY_PUPIL_RADIUS = 0.11;
@@ -106,7 +89,10 @@ export function createClippyController({ THREE, scene, initialState, avatarId })
   });
 
   if (mouthRig?.group) {
-    clippy.mouth = mouthRig.group;
+    // Hide the original mouth mesh from clippy-3d — the rig replaces it
+    if (clippy.mouth) clippy.mouth.visible = false;
+    // Add the rig group into the head so it moves with the avatar
+    clippy.head.add(mouthRig.group);
   }
 
   const availableModes = typeof clippy.listAnimations === "function" ? clippy.listAnimations() : FALLBACK_MODES;
@@ -135,7 +121,6 @@ export function createClippyController({ THREE, scene, initialState, avatarId })
 
   const base = {
     head: clippy.head.position.clone(),
-    mouthZ: clippy.mouth.position.z,
     browSpacing: Math.abs(clippy.leftBrow.position.x),
     leftPupilX: clippy.leftPupil.position.x,
     rightPupilX: clippy.rightPupil.position.x,
@@ -213,7 +198,6 @@ export function createClippyController({ THREE, scene, initialState, avatarId })
     clippy.head.scale.setScalar(state.headScale);
 
     const expr = expressionProfile(state.expression);
-    voiceRuntime.expression = expr;
     const headWaveOffset = clippy.head.position.y - base.head.y;
     clippy.head.position.x = base.head.x + state.headX;
     clippy.head.position.y = base.head.y + headWaveOffset + state.headY;
@@ -275,15 +259,6 @@ export function createClippyController({ THREE, scene, initialState, avatarId })
     clippy.leftBrow.scale.setScalar(state.browScale);
     clippy.rightBrow.scale.setScalar(state.browScale);
 
-    const mouthOffsetY = Number.isFinite(state.mouthOffsetY) ? state.mouthOffsetY : 0;
-    const mouthOffsetZ = mouthOffsetY * MOUTH_OFFSET_Z_FACTOR;
-    clippy.mouth.scale.x = state.mouthWidth;
-    const mouthScaleY = expr.mouthScaleY * state.mouthHeight;
-    const mouthScaleAnchorY = (1 - mouthScaleY) * MOUTH_SCALE_ANCHOR_Y;
-    clippy.mouth.scale.y = mouthScaleY;
-    clippy.mouth.position.y = expr.mouthShiftY + mouthOffsetY + mouthScaleAnchorY;
-    clippy.mouth.position.z = base.mouthZ + mouthOffsetZ;
-
     clippy.leftArm.pivot.position.x = -state.armSpread;
     clippy.rightArm.pivot.position.x = state.armSpread;
     clippy.leftArm.pivot.position.y = state.armY;
@@ -326,12 +301,10 @@ export function createClippyController({ THREE, scene, initialState, avatarId })
   }
 
   function applyMouthPlacement() {
-    if (!clippy.mouth) return;
-    clippy.mouth.position.x = state.mouthRigX;
-    clippy.mouth.position.y = state.mouthRigY;
-    clippy.mouth.position.z = state.mouthRigZ;
-    clippy.mouth.scale.setScalar(state.mouthRigScale);
-    clippy.mouth.rotation.set(state.mouthRigRotX, state.mouthRigRotY, state.mouthRigRotZ);
+    if (!mouthRig?.group) return;
+    mouthRig.group.position.set(state.mouthRigX, state.mouthRigY, state.mouthRigZ);
+    mouthRig.group.scale.setScalar(state.mouthRigScale);
+    mouthRig.group.rotation.set(state.mouthRigRotX, state.mouthRigRotY, state.mouthRigRotZ);
   }
 
   function applyVoiceFrame(dt) {

--- a/js/avatars/thumbtack-controller.js
+++ b/js/avatars/thumbtack-controller.js
@@ -2,11 +2,13 @@ import { createThumbTackAvatar, expressionProfile } from "../lib/thumbtack-facto
 import { clamp, constrainPupilToEyeSurface } from "../lib/utils.js";
 import { registerEngine } from "../engines.js";
 import { createPropManager, listSharedProps, getSharedProp, loadPropPlacement, savePropPlacement, applyPlacementToObject } from "../lib/prop-system.js";
+import { createUniversalMouth } from "../lib/mouth-rig.js";
 import "../lib/shared-props.js";
 import { NO_PROP_VALUE } from "../config/avatars.js";
 
 const MODE_CHOICES = ["idle", "bob", "wave", "spin", "celebrate"];
 const EXPRESSION_CHOICES = ["neutral", "smile", "determined", "startled"];
+const SIL_VISEME = "sil";
 const THUMBTACK_EYE_RADIUS = 0.07;
 const THUMBTACK_PUPIL_RADIUS = 0.033;
 const THUMBTACK_PUPIL_SURFACE_SETTINGS = Object.freeze({
@@ -19,6 +21,24 @@ export function createThumbtackController({ THREE, scene, initialState, profile,
   const state = { ...initialState };
   const avatar = createThumbTackAvatar(THREE, state, profile);
   scene.add(avatar.group);
+
+  // Create universal mouth rig and attach to face
+  const mouthRig = createUniversalMouth({
+    THREE,
+    anchor: avatar.faceRoot,
+    options: {
+      lipColor: 0xb53b4e,
+      cavityColor: new THREE.Color(state.darkColor).multiplyScalar(0.4).getHex(),
+      tongueColor: 0x7d3445,
+      shadowColor: new THREE.Color(state.darkColor).multiplyScalar(0.26).getHex(),
+      shadowOpacity: 0.6,
+    },
+  });
+
+  // Hide the old simple mouth line (if desired)
+  if (avatar.mouth) {
+    avatar.mouth.visible = false;
+  }
 
   const geometryCache = {
     shapeKey: "",
@@ -40,8 +60,8 @@ export function createThumbtackController({ THREE, scene, initialState, profile,
     baseY: 0,
     expression: expressionProfile(state.expression),
     voiceTarget: 0,
-    voiceCurrent: 0,
-    voicePhase: Math.random() * Math.PI * 2,
+    visemeKey: SIL_VISEME,
+    visemeStrength: 0,
   };
 
   function updateMaterials() {
@@ -206,21 +226,54 @@ export function createThumbtackController({ THREE, scene, initialState, profile,
     });
   }
 
+  function loadMouthPlacement() {
+    const storageKey = `mouth-placement:${avatarId}`;
+    try {
+      const saved = localStorage.getItem(storageKey);
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        state.mouthRigX = parsed.x ?? state.mouthRigX;
+        state.mouthRigY = parsed.y ?? state.mouthRigY;
+        state.mouthRigZ = parsed.z ?? state.mouthRigZ;
+        state.mouthRigScale = parsed.scale ?? state.mouthRigScale;
+        state.mouthRigRotX = parsed.rotX ?? state.mouthRigRotX;
+        state.mouthRigRotY = parsed.rotY ?? state.mouthRigRotY;
+        state.mouthRigRotZ = parsed.rotZ ?? state.mouthRigRotZ;
+      }
+    } catch { /* ignore */ }
+  }
+
+  function saveMouthPlacement() {
+    const storageKey = `mouth-placement:${avatarId}`;
+    try {
+      localStorage.setItem(storageKey, JSON.stringify({
+        x: state.mouthRigX,
+        y: state.mouthRigY,
+        z: state.mouthRigZ,
+        scale: state.mouthRigScale,
+        rotX: state.mouthRigRotX,
+        rotY: state.mouthRigRotY,
+        rotZ: state.mouthRigRotZ,
+      }));
+    } catch { /* ignore */ }
+  }
+
+  function applyMouthPlacement() {
+    if (!mouthRig?.group) return;
+    mouthRig.group.position.set(state.mouthRigX, state.mouthRigY, state.mouthRigZ);
+    mouthRig.group.scale.setScalar(state.mouthRigScale);
+    mouthRig.group.rotation.set(state.mouthRigRotX, state.mouthRigRotY, state.mouthRigRotZ);
+  }
+
   function applyVoiceFrame(dt) {
-    if (!avatar.mouth) return;
+    if (!mouthRig) return;
 
-    const smoothing = runtime.voiceTarget > runtime.voiceCurrent ? 0.38 : 0.2;
-    runtime.voiceCurrent += (runtime.voiceTarget - runtime.voiceCurrent) * smoothing;
-    if (runtime.voiceCurrent < 0.004) runtime.voiceCurrent = 0;
-
-    runtime.voicePhase += dt * (24 + runtime.voiceCurrent * 32);
-
-    const flutter = Math.sin(runtime.voicePhase) * 0.08 * runtime.voiceCurrent;
-    const open = clamp(runtime.voiceCurrent * 0.72 + flutter, 0, 1.2);
-    const widen = 1 + runtime.voiceCurrent * 0.16;
-
-    avatar.mouth.scale.set(widen, 1 + open, widen);
-    avatar.mouth.position.y = -0.11 + runtime.expression.mouthY - runtime.voiceCurrent * 0.018;
+    // Delegate voice animation to the universal mouth rig
+    mouthRig.applyVoiceFrame(dt, {
+      viseme: runtime.visemeKey,
+      visemeStrength: runtime.visemeStrength,
+      voiceActivity: runtime.voiceTarget,
+    });
   }
 
   function applyPropPlacement() {
@@ -277,6 +330,7 @@ export function createThumbtackController({ THREE, scene, initialState, profile,
     updateMaterials();
     syncProp(force);
     applyPropPlacement();
+    applyMouthPlacement();
     if (currentPropName !== NO_PROP_VALUE) {
       savePropPlacement(currentPropName, avatarId, {
         x: state.propX, y: state.propY, z: state.propZ,
@@ -284,6 +338,7 @@ export function createThumbtackController({ THREE, scene, initialState, profile,
         rotX: state.propRotX, rotY: state.propRotY, rotZ: state.propRotZ,
       });
     }
+    saveMouthPlacement();
   }
 
   function update(dt, pointer) {
@@ -303,9 +358,11 @@ export function createThumbtackController({ THREE, scene, initialState, profile,
     runtime.voiceTarget = clamp(Number.isFinite(next) ? next : 0, 0, 1);
   }
 
-  function setVoiceViseme(_payload) {
-    // Thumbtack uses voice-activity-driven mouth animation;
-    // viseme-specific shaping is not yet implemented for this engine.
+  function setVoiceViseme(payload = null) {
+    const key = String(payload?.viseme || SIL_VISEME).toLowerCase();
+    runtime.visemeKey = key;
+    const nextStrength = Number(payload?.strength);
+    runtime.visemeStrength = clamp(Number.isFinite(nextStrength) ? nextStrength : 0, 0, 1);
   }
 
   function dispose() {
@@ -313,6 +370,9 @@ export function createThumbtackController({ THREE, scene, initialState, profile,
     scene.remove(avatar.group);
     avatar.dispose();
   }
+
+  // Load saved mouth placement from localStorage
+  loadMouthPlacement();
 
   setState(state, { force: true });
 

--- a/js/avatars/thumbtack-controller.js
+++ b/js/avatars/thumbtack-controller.js
@@ -35,9 +35,10 @@ export function createThumbtackController({ THREE, scene, initialState, profile,
     },
   });
 
-  // Hide the old simple mouth line (if desired)
-  if (avatar.mouth) {
-    avatar.mouth.visible = false;
+  if (mouthRig?.group) {
+    // Hide the old simple mouth line — the rig replaces it
+    if (avatar.mouth) avatar.mouth.visible = false;
+    avatar.faceRoot.add(mouthRig.group);
   }
 
   const geometryCache = {

--- a/js/avatars/towely-controller.js
+++ b/js/avatars/towely-controller.js
@@ -2,11 +2,13 @@ import { createTowelyAvatar } from "../lib/towely-factory.js";
 import { clamp } from "../lib/utils.js";
 import { registerEngine } from "../engines.js";
 import { createPropManager, listSharedProps, getSharedProp, loadPropPlacement, savePropPlacement, applyPlacementToObject } from "../lib/prop-system.js";
+import { createUniversalMouth } from "../lib/mouth-rig.js";
 import "../lib/shared-props.js";
 import { NO_PROP_VALUE } from "../config/avatars.js";
 
 const MODE_CHOICES = ["idle", "bob", "wave", "spin", "celebrate"];
 const EXPRESSION_CHOICES = ["neutral", "smug", "angry", "startled"];
+const SIL_VISEME = "sil";
 
 function expressionProfile(expression) {
   if (expression === "smug") {
@@ -151,6 +153,24 @@ export function createTowelyController({ THREE, scene, initialState, stageTopY, 
   const avatar = createTowelyAvatar(THREE, state);
   scene.add(avatar.group);
 
+  // Create universal mouth rig and attach to face
+  const mouthRig = createUniversalMouth({
+    THREE,
+    anchor: avatar.faceRoot,
+    options: {
+      lipColor: 0xb53b4e,
+      cavityColor: new THREE.Color(state.darkColor).multiplyScalar(0.4).getHex(),
+      tongueColor: 0x7d3445,
+      shadowColor: new THREE.Color(state.darkColor).multiplyScalar(0.26).getHex(),
+      shadowOpacity: 0.6,
+    },
+  });
+
+  // Hide the old simple smile mesh (if desired)
+  if (avatar.smile) {
+    avatar.smile.visible = false;
+  }
+
   const propManager = createPropManager();
   const sharedPropNames = listSharedProps();
   let currentPropName = NO_PROP_VALUE;
@@ -180,8 +200,8 @@ export function createTowelyController({ THREE, scene, initialState, stageTopY, 
     blinkTimer: 0,
     blinkOffset: 0.34,
     voiceTarget: 0,
-    voiceCurrent: 0,
-    voicePhase: Math.random() * Math.PI * 2,
+    visemeKey: SIL_VISEME,
+    visemeStrength: 0,
   };
 
   function updateMaterials() {
@@ -423,21 +443,54 @@ export function createTowelyController({ THREE, scene, initialState, stageTopY, 
     avatar.rightPupil.scale.set(runtime.pupilBaseScale, runtime.pupilBaseScale * pupilYScale, 1);
   }
 
+  function loadMouthPlacement() {
+    const storageKey = `mouth-placement:${avatarId}`;
+    try {
+      const saved = localStorage.getItem(storageKey);
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        state.mouthRigX = parsed.x ?? state.mouthRigX;
+        state.mouthRigY = parsed.y ?? state.mouthRigY;
+        state.mouthRigZ = parsed.z ?? state.mouthRigZ;
+        state.mouthRigScale = parsed.scale ?? state.mouthRigScale;
+        state.mouthRigRotX = parsed.rotX ?? state.mouthRigRotX;
+        state.mouthRigRotY = parsed.rotY ?? state.mouthRigRotY;
+        state.mouthRigRotZ = parsed.rotZ ?? state.mouthRigRotZ;
+      }
+    } catch { /* ignore */ }
+  }
+
+  function saveMouthPlacement() {
+    const storageKey = `mouth-placement:${avatarId}`;
+    try {
+      localStorage.setItem(storageKey, JSON.stringify({
+        x: state.mouthRigX,
+        y: state.mouthRigY,
+        z: state.mouthRigZ,
+        scale: state.mouthRigScale,
+        rotX: state.mouthRigRotX,
+        rotY: state.mouthRigRotY,
+        rotZ: state.mouthRigRotZ,
+      }));
+    } catch { /* ignore */ }
+  }
+
+  function applyMouthPlacement() {
+    if (!mouthRig?.group) return;
+    mouthRig.group.position.set(state.mouthRigX, state.mouthRigY, state.mouthRigZ);
+    mouthRig.group.scale.setScalar(state.mouthRigScale);
+    mouthRig.group.rotation.set(state.mouthRigRotX, state.mouthRigRotY, state.mouthRigRotZ);
+  }
+
   function applyVoiceFrame(dt) {
-    const smoothing = runtime.voiceTarget > runtime.voiceCurrent ? 0.38 : 0.2;
-    runtime.voiceCurrent += (runtime.voiceTarget - runtime.voiceCurrent) * smoothing;
-    if (runtime.voiceCurrent < 0.004) runtime.voiceCurrent = 0;
+    if (!mouthRig) return;
 
-    runtime.voicePhase += dt * (24 + runtime.voiceCurrent * 32);
-
-    const flutter = Math.sin(runtime.voicePhase) * 0.06 * runtime.voiceCurrent;
-    const open = clamp(runtime.voiceCurrent * 0.72 + flutter, 0, 1.2);
-
-    const expr = expressionProfile(state.expression);
-    const mouthWidth = clamp(state.mouthWidth * expr.mouthWidth, 0.6, 1.8);
-    const mouthOpen = clamp(state.mouthOpen + expr.mouthOpen + open, 0, 1.3);
-
-    avatar.smile.scale.set(0.88 * mouthWidth, 0.86 + mouthOpen * 0.16, 1);
+    // Delegate voice animation to the universal mouth rig
+    mouthRig.applyVoiceFrame(dt, {
+      viseme: runtime.visemeKey,
+      visemeStrength: runtime.visemeStrength,
+      voiceActivity: runtime.voiceTarget,
+    });
   }
 
   function applyPropPlacement() {
@@ -505,6 +558,7 @@ export function createTowelyController({ THREE, scene, initialState, stageTopY, 
     updateMaterials();
     syncProp(force);
     applyPropPlacement();
+    applyMouthPlacement();
     if (currentPropName !== NO_PROP_VALUE) {
       savePropPlacement(currentPropName, avatarId, {
         x: state.propX, y: state.propY, z: state.propZ,
@@ -512,6 +566,7 @@ export function createTowelyController({ THREE, scene, initialState, stageTopY, 
         rotX: state.propRotX, rotY: state.propRotY, rotZ: state.propRotZ,
       });
     }
+    saveMouthPlacement();
   }
 
   function update(dt, pointer) {
@@ -531,9 +586,11 @@ export function createTowelyController({ THREE, scene, initialState, stageTopY, 
     runtime.voiceTarget = clamp(Number.isFinite(next) ? next : 0, 0, 1);
   }
 
-  function setVoiceViseme(_payload) {
-    // Towely uses voice-activity-driven mouth animation;
-    // viseme-specific shaping is not yet implemented for this engine.
+  function setVoiceViseme(payload = null) {
+    const key = String(payload?.viseme || SIL_VISEME).toLowerCase();
+    runtime.visemeKey = key;
+    const nextStrength = Number(payload?.strength);
+    runtime.visemeStrength = clamp(Number.isFinite(nextStrength) ? nextStrength : 0, 0, 1);
   }
 
   function dispose() {
@@ -541,6 +598,9 @@ export function createTowelyController({ THREE, scene, initialState, stageTopY, 
     scene.remove(avatar.group);
     avatar.dispose();
   }
+
+  // Load saved mouth placement from localStorage
+  loadMouthPlacement();
 
   setState(state, { force: true });
 

--- a/js/avatars/towely-controller.js
+++ b/js/avatars/towely-controller.js
@@ -166,9 +166,10 @@ export function createTowelyController({ THREE, scene, initialState, stageTopY, 
     },
   });
 
-  // Hide the old simple smile mesh (if desired)
-  if (avatar.smile) {
-    avatar.smile.visible = false;
+  if (mouthRig?.group) {
+    // Hide the old simple smile mesh — the rig replaces it
+    if (avatar.smile) avatar.smile.visible = false;
+    avatar.faceRoot.add(mouthRig.group);
   }
 
   const propManager = createPropManager();

--- a/js/config/avatars.js
+++ b/js/config/avatars.js
@@ -48,6 +48,18 @@ const clippyFields = [
     ],
   },
   {
+    title: "Mouth Placement",
+    fields: [
+      { key: "mouthRigX", label: "Mouth X", type: "range", min: -0.5, max: 0.5, step: 0.01 },
+      { key: "mouthRigY", label: "Mouth Y", type: "range", min: -0.5, max: 0.5, step: 0.01 },
+      { key: "mouthRigZ", label: "Mouth Z", type: "range", min: -0.3, max: 0.3, step: 0.01 },
+      { key: "mouthRigScale", label: "Mouth Scale", type: "range", min: 0.3, max: 2.5, step: 0.01 },
+      { key: "mouthRigRotX", label: "Mouth Tilt X", type: "range", min: -3.14, max: 3.14, step: 0.01 },
+      { key: "mouthRigRotY", label: "Mouth Tilt Y", type: "range", min: -3.14, max: 3.14, step: 0.01 },
+      { key: "mouthRigRotZ", label: "Mouth Tilt Z", type: "range", min: -3.14, max: 3.14, step: 0.01 },
+    ],
+  },
+  {
     title: "Shape",
     fields: [
       { key: "scale", label: "Body Scale", type: "range", min: 0.35, max: 2.2, step: 0.01 },
@@ -134,6 +146,18 @@ const pinFields = [
     ],
   },
   {
+    title: "Mouth Placement",
+    fields: [
+      { key: "mouthRigX", label: "Mouth X", type: "range", min: -0.5, max: 0.5, step: 0.01 },
+      { key: "mouthRigY", label: "Mouth Y", type: "range", min: -0.5, max: 0.5, step: 0.01 },
+      { key: "mouthRigZ", label: "Mouth Z", type: "range", min: -0.3, max: 0.3, step: 0.01 },
+      { key: "mouthRigScale", label: "Mouth Scale", type: "range", min: 0.3, max: 2.5, step: 0.01 },
+      { key: "mouthRigRotX", label: "Mouth Tilt X", type: "range", min: -3.14, max: 3.14, step: 0.01 },
+      { key: "mouthRigRotY", label: "Mouth Tilt Y", type: "range", min: -3.14, max: 3.14, step: 0.01 },
+      { key: "mouthRigRotZ", label: "Mouth Tilt Z", type: "range", min: -3.14, max: 3.14, step: 0.01 },
+    ],
+  },
+  {
     title: "Shape",
     fields: [
       { key: "scale", label: "Body Scale", type: "range", min: 0.4, max: 2.2, step: 0.01 },
@@ -217,6 +241,18 @@ const towelyFields = [
     ],
   },
   {
+    title: "Mouth Placement",
+    fields: [
+      { key: "mouthRigX", label: "Mouth X", type: "range", min: -0.5, max: 0.5, step: 0.01 },
+      { key: "mouthRigY", label: "Mouth Y", type: "range", min: -0.5, max: 0.5, step: 0.01 },
+      { key: "mouthRigZ", label: "Mouth Z", type: "range", min: -0.3, max: 0.3, step: 0.01 },
+      { key: "mouthRigScale", label: "Mouth Scale", type: "range", min: 0.3, max: 2.5, step: 0.01 },
+      { key: "mouthRigRotX", label: "Mouth Tilt X", type: "range", min: -3.14, max: 3.14, step: 0.01 },
+      { key: "mouthRigRotY", label: "Mouth Tilt Y", type: "range", min: -3.14, max: 3.14, step: 0.01 },
+      { key: "mouthRigRotZ", label: "Mouth Tilt Z", type: "range", min: -3.14, max: 3.14, step: 0.01 },
+    ],
+  },
+  {
     title: "Shape",
     fields: [
       { key: "scale", label: "Body Scale", type: "range", min: 0.4, max: 2.2, step: 0.01 },
@@ -283,6 +319,14 @@ export const AVATAR_DEFINITIONS = {
       propRotY: 0,
       propRotZ: 0,
 
+      mouthRigX: 0,
+      mouthRigY: -0.34,
+      mouthRigZ: 0,
+      mouthRigScale: 1,
+      mouthRigRotX: 0,
+      mouthRigRotY: 0,
+      mouthRigRotZ: 0,
+
       scale: 0.54,
       wireThickness: 1.79,
       headScale: 1,
@@ -338,6 +382,14 @@ export const AVATAR_DEFINITIONS = {
       propRotY: 0,
       propRotZ: 0,
 
+      mouthRigX: 0,
+      mouthRigY: -0.11,
+      mouthRigZ: 0.062,
+      mouthRigScale: 0.5,
+      mouthRigRotX: 0,
+      mouthRigRotY: 0,
+      mouthRigRotZ: 0,
+
       scale: 0.72,
       wireThickness: 0.024,
       crownWidth: 1.29,
@@ -390,6 +442,14 @@ export const AVATAR_DEFINITIONS = {
       propRotY: 0,
       propRotZ: 0,
 
+      mouthRigX: 0,
+      mouthRigY: -0.11,
+      mouthRigZ: 0.062,
+      mouthRigScale: 0.5,
+      mouthRigRotX: 0,
+      mouthRigRotY: 0,
+      mouthRigRotZ: 0,
+
       scale: 0.74,
       wireThickness: 0.03,
       crownWidth: 1.36,
@@ -440,6 +500,14 @@ export const AVATAR_DEFINITIONS = {
       propRotX: 0,
       propRotY: 0,
       propRotZ: 0,
+
+      mouthRigX: 0,
+      mouthRigY: -0.18,
+      mouthRigZ: 0.2,
+      mouthRigScale: 1.2,
+      mouthRigRotX: 0,
+      mouthRigRotY: 0,
+      mouthRigRotZ: 0,
 
       scale: 0.73,
       bodyWidth: 1,

--- a/js/lib/mouth-rig.js
+++ b/js/lib/mouth-rig.js
@@ -149,9 +149,9 @@ export function createUniversalMouth({ THREE, anchor, options = {} }) {
   tongue.position.set(0, -0.052, -0.014);
   tongue.scale.set(0.72, 0.26, 1);
 
-  // Initially hide all elements (shown when voice activity detected)
-  upperLip.visible = false;
-  lowerLip.visible = false;
+  // Lips are always visible (closed resting pose); interior hides at rest
+  upperLip.visible = true;
+  lowerLip.visible = true;
   cavity.visible = false;
   cavityShadow.visible = false;
   tongue.visible = false;
@@ -244,20 +244,20 @@ export function createUniversalMouth({ THREE, anchor, options = {} }) {
       clamp(activity * 0.12 + runtime.voiceCurrent * 0.09, 0, 0.14);
     const bridgeOpen = clamp((aperture + bridgeBoost) * (1 - bilabialLock * 0.95), 0, 1.16);
 
-    // Determine rig visibility
-    let useRig =
+    // Lips are always visible; interior only shows during speech
+    const mouthOpen =
       aperture > 0.11 || runtime.voiceCurrent > 0.22 || runtime.visemeStrengthCurrent > 0.1;
-    if (bilabialLock > 0.36) {
-      useRig = false;
-    }
+    const showInterior = mouthOpen && bilabialLock <= 0.36;
 
-    upperLip.visible = useRig;
-    lowerLip.visible = useRig;
-
-    if (!useRig) {
+    if (!showInterior) {
       cavity.visible = false;
       cavityShadow.visible = false;
       tongue.visible = false;
+      // Reset lips to closed resting position (flattened into a line)
+      upperLip.position.y = 0.001;
+      lowerLip.position.y = -0.001;
+      upperLip.scale.set(1, 0.18, 1);
+      lowerLip.scale.set(1, 0.18, 1);
       return;
     }
 

--- a/js/lib/mouth-rig.js
+++ b/js/lib/mouth-rig.js
@@ -1,0 +1,336 @@
+/**
+ * Universal mouth rig system for viseme-driven lip animation across all avatars.
+ *
+ * Creates a multi-layer mouth with upper/lower lips, oral cavity, tongue, and shadow.
+ * Animates via viseme poses (aa, ee, oh, ou, fv, mbp, th, ch, etc.) blended with
+ * voice activity level, providing rich bilabial, aperture, and jaw motion.
+ *
+ * Usage:
+ *   const mouth = createUniversalMouth({ THREE, anchor, options });
+ *   anchor.add(mouth.group);
+ *   // In animation loop:
+ *   mouth.applyVoiceFrame(dt, { viseme, visemeStrength, voiceActivity });
+ *   // Cleanup:
+ *   mouth.dispose();
+ */
+
+import { clamp } from "./utils.js";
+
+const SIL_VISEME = "sil";
+
+/**
+ * Viseme pose definitions mapping phoneme groups to mouth shape parameters.
+ * Each pose defines:
+ *   - open: vertical aperture (jaw drop)
+ *   - width: horizontal spread
+ *   - round: lip rounding (protrusion)
+ *   - press: lip compression (seal strength)
+ *   - jaw: additional jaw contribution
+ */
+export const VISEME_POSES = Object.freeze({
+  sil: { open: 0, width: 1, round: 0, press: 1, jaw: 0 },          // silence
+  aa: { open: 0.82, width: 1.11, round: 0.08, press: 0.05, jaw: 0.52 },  // "father"
+  ee: { open: 0.32, width: 1.3, round: -0.14, press: 0.08, jaw: 0.12 },  // "see"
+  oh: { open: 0.66, width: 0.9, round: 0.72, press: 0.09, jaw: 0.32 },   // "go"
+  ou: { open: 0.48, width: 0.8, round: 0.84, press: 0.12, jaw: 0.2 },    // "you"
+  fv: { open: 0.16, width: 1.02, round: 0.02, press: 0.45, jaw: 0.04 },  // "five"
+  mbp: { open: 0, width: 1, round: 0, press: 1, jaw: 0 },          // "map", bilabial
+  th: { open: 0.36, width: 1.08, round: 0.1, press: 0.22, jaw: 0.16 },   // "think"
+  ch: { open: 0.44, width: 1.01, round: 0.18, press: 0.2, jaw: 0.2 },    // "cheese"
+  tn: { open: 0.24, width: 1.08, round: 0.04, press: 0.28, jaw: 0.1 },   // "tan"
+  ss: { open: 0.14, width: 1.22, round: -0.04, press: 0.24, jaw: 0.06 }, // "see"
+  kk: { open: 0.28, width: 1.02, round: 0.06, press: 0.26, jaw: 0.12 },  // "key"
+});
+
+/**
+ * Blend two viseme poses by interpolating all parameters.
+ */
+export function blendPose(base, target, amount) {
+  const mix = clamp(amount, 0, 1);
+  return {
+    open: base.open + (target.open - base.open) * mix,
+    width: base.width + (target.width - base.width) * mix,
+    round: base.round + (target.round - base.round) * mix,
+    press: base.press + (target.press - base.press) * mix,
+    jaw: base.jaw + (target.jaw - base.jaw) * mix,
+  };
+}
+
+function disposeObject3D(root) {
+  if (!root) return;
+  root.traverse((node) => {
+    if (node.geometry && typeof node.geometry.dispose === "function") {
+      node.geometry.dispose();
+    }
+    if (!node.material) return;
+    const mats = Array.isArray(node.material) ? node.material : [node.material];
+    for (const mat of mats) {
+      if (mat && typeof mat.dispose === "function") {
+        mat.dispose();
+      }
+    }
+  });
+}
+
+/**
+ * Create a universal mouth rig.
+ *
+ * @param {object} config
+ * @param {THREE} config.THREE - Three.js library
+ * @param {THREE.Object3D} config.anchor - Parent anchor (typically faceRoot or head)
+ * @param {object} config.options - Configuration options
+ * @param {number} config.options.lipColor - Hex color for lips (default: 0xb53b4e)
+ * @param {number} config.options.cavityColor - Hex color for oral cavity (default: 0x070b16)
+ * @param {number} config.options.tongueColor - Hex color for tongue (default: 0x7d3445)
+ * @param {number} config.options.shadowColor - Hex color for cavity shadow (default: 0x02040a)
+ * @param {number} config.options.shadowOpacity - Opacity for shadow layer (default: 0.6)
+ * @returns {object} Mouth rig instance with { group, applyVoiceFrame, dispose }
+ */
+export function createUniversalMouth({ THREE, anchor, options = {} }) {
+  if (!THREE || !anchor) {
+    console.warn("createUniversalMouth: THREE and anchor are required");
+    return null;
+  }
+
+  const lipColor = options.lipColor ?? 0xb53b4e;
+  const cavityColor = options.cavityColor ?? 0x070b16;
+  const tongueColor = options.tongueColor ?? 0x7d3445;
+  const shadowColor = options.shadowColor ?? 0x02040a;
+  const shadowOpacity = options.shadowOpacity ?? 0.6;
+
+  // Root group for the entire mouth assembly
+  const group = new THREE.Group();
+
+  // Create materials
+  const lipMaterial = new THREE.MeshStandardMaterial({
+    color: lipColor,
+    metalness: 0.2,
+    roughness: 0.65,
+  });
+
+  const cavityMaterial = new THREE.MeshBasicMaterial({ color: cavityColor });
+
+  const shadowMaterial = new THREE.MeshBasicMaterial({
+    color: shadowColor,
+    transparent: true,
+    opacity: shadowOpacity,
+    depthWrite: false,
+  });
+
+  const tongueMaterial = new THREE.MeshStandardMaterial({
+    color: tongueColor,
+    metalness: 0.02,
+    roughness: 0.88,
+  });
+
+  // Create mouth geometry elements
+  const upperLip = new THREE.Mesh(
+    new THREE.TorusGeometry(0.16, 0.024, 12, 38, Math.PI),
+    lipMaterial,
+  );
+  upperLip.rotation.z = Math.PI;
+  upperLip.position.y = 0.008;
+
+  const lowerLip = new THREE.Mesh(
+    new THREE.TorusGeometry(0.16, 0.026, 12, 38, Math.PI),
+    lipMaterial,
+  );
+  lowerLip.position.y = -0.008;
+
+  const cavity = new THREE.Mesh(new THREE.CircleGeometry(0.13, 32), cavityMaterial);
+  cavity.position.z = -0.008;
+  cavity.scale.set(0.84, 0.08, 1);
+
+  const cavityShadow = new THREE.Mesh(new THREE.CircleGeometry(0.136, 32), shadowMaterial);
+  cavityShadow.position.set(0, -0.006, -0.018);
+  cavityShadow.scale.set(0.92, 0.12, 1);
+
+  const tongue = new THREE.Mesh(new THREE.CircleGeometry(0.078, 24), tongueMaterial);
+  tongue.position.set(0, -0.052, -0.014);
+  tongue.scale.set(0.72, 0.26, 1);
+
+  // Initially hide all elements (shown when voice activity detected)
+  upperLip.visible = false;
+  lowerLip.visible = false;
+  cavity.visible = false;
+  cavityShadow.visible = false;
+  tongue.visible = false;
+
+  group.add(cavityShadow, cavity, tongue, upperLip, lowerLip);
+
+  // Voice animation runtime state
+  const runtime = {
+    voiceTarget: 0,
+    voiceCurrent: 0,
+    visemeKey: SIL_VISEME,
+    visemeStrengthTarget: 0,
+    visemeStrengthCurrent: 0,
+    poseCurrent: { ...VISEME_POSES[SIL_VISEME] },
+    phase: Math.random() * Math.PI * 2,
+  };
+
+  /**
+   * Apply voice-driven animation frame to the mouth rig.
+   *
+   * @param {number} dt - Delta time in seconds
+   * @param {object} voiceState - Voice state
+   * @param {string} voiceState.viseme - Current viseme key (e.g., "aa", "ee", "oh")
+   * @param {number} voiceState.visemeStrength - Viseme blend strength (0-1)
+   * @param {number} voiceState.voiceActivity - Overall voice activity level (0-1)
+   */
+  function applyVoiceFrame(dt, voiceState = {}) {
+    const { viseme = SIL_VISEME, visemeStrength = 0, voiceActivity = 0 } = voiceState;
+
+    // Update runtime targets
+    runtime.voiceTarget = clamp(Number(voiceActivity) || 0, 0, 1);
+    runtime.visemeKey = Object.prototype.hasOwnProperty.call(VISEME_POSES, viseme)
+      ? viseme
+      : SIL_VISEME;
+    runtime.visemeStrengthTarget = clamp(Number(visemeStrength) || 0, 0, 1);
+
+    // Smooth voice activity level
+    const levelSmoothing = runtime.voiceTarget > runtime.voiceCurrent ? 0.36 : 0.22;
+    runtime.voiceCurrent += (runtime.voiceTarget - runtime.voiceCurrent) * levelSmoothing;
+    if (runtime.voiceCurrent < 0.004) runtime.voiceCurrent = 0;
+
+    // Smooth viseme strength
+    const visemeSmoothing = runtime.visemeStrengthTarget > runtime.visemeStrengthCurrent ? 0.4 : 0.24;
+    runtime.visemeStrengthCurrent += (runtime.visemeStrengthTarget - runtime.visemeStrengthCurrent) * visemeSmoothing;
+    if (runtime.visemeStrengthCurrent < 0.004) runtime.visemeStrengthCurrent = 0;
+
+    // Blend from silence to target viseme pose
+    const targetPose = VISEME_POSES[runtime.visemeKey] || VISEME_POSES[SIL_VISEME];
+    const mixedPose = blendPose(VISEME_POSES[SIL_VISEME], targetPose, runtime.visemeStrengthCurrent);
+
+    // Smooth pose transitions
+    for (const key of ["open", "width", "round", "press", "jaw"]) {
+      const from = runtime.poseCurrent[key];
+      const to = mixedPose[key];
+      runtime.poseCurrent[key] = from + (to - from) * 0.34;
+    }
+
+    // Compute overall activity
+    const activity = clamp(
+      runtime.voiceCurrent * 0.8 + runtime.visemeStrengthCurrent * 0.64,
+      0,
+      1,
+    );
+
+    // Add micro-flutter for realism
+    runtime.phase += dt * (14 + activity * 20);
+    const flutter = Math.sin(runtime.phase) * 0.04 * activity;
+
+    // Extract pose parameters
+    const openAmount = clamp(
+      runtime.poseCurrent.open * (0.14 + activity * 0.66) + flutter,
+      0,
+      1.1,
+    );
+    const widthAmount = clamp(runtime.poseCurrent.width + activity * 0.05, 0.74, 1.45);
+    const roundAmount = clamp(runtime.poseCurrent.round, -0.22, 0.92);
+    const pressAmount = clamp(runtime.poseCurrent.press, 0, 1);
+    const jawAmount = clamp(runtime.poseCurrent.jaw, 0, 1);
+
+    const sealAmount = clamp(pressAmount * (1 - activity * 0.28), 0, 1);
+    const aperture = clamp(openAmount * (1 - sealAmount * 0.58), 0, 1.2);
+
+    // Bilabial closure (lips fully pressed together)
+    const isBilabial = runtime.visemeKey === "mbp";
+    const bilabialLock = isBilabial ? runtime.visemeStrengthCurrent : 0;
+
+    // Bridge boost for subtle lip contact during light articulation
+    const bridgeBoost =
+      clamp((0.24 - aperture) / 0.24, 0, 1) *
+      clamp(activity * 0.12 + runtime.voiceCurrent * 0.09, 0, 0.14);
+    const bridgeOpen = clamp((aperture + bridgeBoost) * (1 - bilabialLock * 0.95), 0, 1.16);
+
+    // Determine rig visibility
+    let useRig =
+      aperture > 0.11 || runtime.voiceCurrent > 0.22 || runtime.visemeStrengthCurrent > 0.1;
+    if (bilabialLock > 0.36) {
+      useRig = false;
+    }
+
+    upperLip.visible = useRig;
+    lowerLip.visible = useRig;
+
+    if (!useRig) {
+      cavity.visible = false;
+      cavityShadow.visible = false;
+      tongue.visible = false;
+      return;
+    }
+
+    // Animate lips
+    const lipSpread = clamp(1 + (widthAmount - 1) * 0.36 - roundAmount * 0.1, 0.78, 1.48);
+    const closedBlend = clamp((bridgeOpen - 0.03) / 0.14, 0, 1);
+    const upperLift = 0.004 + bridgeOpen * 0.016 - sealAmount * 0.012;
+    const lowerDrop = -0.004 - bridgeOpen * 0.098 - jawAmount * 0.03 + sealAmount * 0.01;
+
+    upperLip.position.y = upperLift;
+    lowerLip.position.y = lowerDrop * closedBlend;
+
+    upperLip.scale.x = lipSpread;
+    lowerLip.scale.x = clamp(lipSpread * (1 + roundAmount * 0.06), 0.76, 1.56);
+
+    upperLip.scale.y = clamp(1 - sealAmount * 0.28 + roundAmount * 0.08, 0.74, 1.24);
+    lowerLip.scale.y = clamp(
+      0.7 + closedBlend * (0.3 - sealAmount * 0.32 + roundAmount * 0.1),
+      0.7,
+      1.28,
+    );
+
+    // Animate oral cavity
+    const cavityOpen = clamp(
+      (bridgeOpen * (0.92 - sealAmount * 0.38) + activity * 0.05) * (1 - bilabialLock * 1.2),
+      0,
+      1.12,
+    );
+    cavity.visible = cavityOpen > 0.03;
+    cavity.scale.x = clamp(
+      1.08 + (lipSpread - 1) * 0.36 + bridgeOpen * 0.06 - roundAmount * 0.04,
+      0.96,
+      1.28,
+    );
+    cavity.scale.y = clamp(0.54 + cavityOpen * 0.72 + roundAmount * 0.08, 0.48, 1.28);
+    cavity.position.y = -0.002 - cavityOpen * 0.055;
+
+    cavityShadow.visible = cavity.visible;
+    cavityShadow.scale.x = clamp(cavity.scale.x * 1.04, 0.96, 1.34);
+    cavityShadow.scale.y = clamp(cavity.scale.y * 1.08, 0.5, 1.42);
+    cavityShadow.position.y = cavity.position.y - 0.003;
+
+    // Animate tongue
+    tongue.visible = cavityOpen > 0.3 && bilabialLock < 0.28;
+    tongue.scale.x = clamp(0.52 + lipSpread * 0.2, 0.42, 0.98);
+    tongue.scale.y = clamp(0.16 + cavityOpen * 0.42, 0.14, 0.72);
+    tongue.position.y = -0.052 - cavityOpen * 0.05;
+  }
+
+  /**
+   * Cleanup all resources.
+   */
+  function dispose() {
+    disposeObject3D(group);
+  }
+
+  return {
+    group,
+    applyVoiceFrame,
+    dispose,
+    // Expose individual elements for advanced customization
+    elements: {
+      upperLip,
+      lowerLip,
+      cavity,
+      cavityShadow,
+      tongue,
+    },
+    materials: {
+      lipMaterial,
+      cavityMaterial,
+      shadowMaterial,
+      tongueMaterial,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Introduces a reusable mouth rig system (`js/lib/mouth-rig.js`) that provides viseme-driven lip animation across all four avatars (Clippy, Pushy, Tacky, Towely)
- Replaces simple voice-activity-driven mouths with rich multi-layer animation: upper/lower lips, oral cavity, tongue, and shadow — driven by 12 viseme poses (aa, ee, oh, ou, fv, mbp, th, ch, tn, ss, kk)
- Adds per-avatar "Mouth Placement" UI controls (position, scale, rotation) with localStorage persistence, following the same pattern as prop placement

## Test plan

- [x] `npm run check` passes (syntax + lint + build)
- [ ] All four avatars display a visible closed mouth at rest
- [ ] Mouth opens and animates with lip separation during voice activity
- [ ] Viseme-specific shapes are visible (e.g., bilabial closure on "mbp")
- [ ] Mouth Placement sliders adjust mouth position/scale/rotation per avatar
- [ ] Placement persists across page reloads via localStorage
- [ ] No regression in Clippy's existing animation quality

Resolves #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)